### PR TITLE
Hotfix: forgot about the text of action for games in the list

### DIFF
--- a/layout/GamesPage.qml
+++ b/layout/GamesPage.qml
@@ -48,10 +48,12 @@ Page {
                 actions: [
                     Action {
                         iconName: "info"
+                        text: i18n.tr("Info")
                         onTriggered: PopupUtils.open(infoOrRulesSheed, parent, {"index":index,"gameTitle":gameTitle,"mainText":gameInfo})
                     },
                     Action {
                         iconName: "view-list-symbolic"
+                        text: i18n.tr("Rules")
                         onTriggered: PopupUtils.open(infoOrRulesSheed, parent, {"index":index,"gameTitle":gameTitle,"mainText":gameRules})
                     }
                 ]


### PR DESCRIPTION
This caused listing the icon names while right-clicking on the game instead of a proper text

After the fix:
![immagine](https://user-images.githubusercontent.com/28359593/67772852-169f0900-fa5b-11e9-9b1f-ec061f107200.png)

Before the fix:
![immagine](https://user-images.githubusercontent.com/28359593/67772900-29b1d900-fa5b-11e9-9652-0398d72e8942.png)
